### PR TITLE
Make Mandarin operators requires spaces to separate so words contains mandarin operators preserved words won't conflict.

### DIFF
--- a/src/CASC-Test/Tests/DiagnosticTest.cs
+++ b/src/CASC-Test/Tests/DiagnosticTest.cs
@@ -221,7 +221,7 @@ namespace CASC_Test.Tests
         [Test]
         public void Evaluator_Unary_Reports_Undefined()
         {
-            var text = @"[正]真";
+            var text = @"[正] 真";
 
             var diagnostics = @"
                 ERROR: Unary operator '+' is not defined for type 'System.Boolean'.

--- a/src/CASC-Test/Tests/LexerTest.cs
+++ b/src/CASC-Test/Tests/LexerTest.cs
@@ -43,14 +43,14 @@ namespace CASC_Test.Tests
         public void Lexer_Lexes_TokenPairs(SyntaxKind t1Kind, string t1Text,
                                            SyntaxKind t2Kind, string t2Text)
         {
-            var text = t1Text + t2Text;
+            var text = $"{t1Text} {t2Text}";
             var tokens = SyntaxTree.ParseTokens(text).ToArray();
 
-            Assert.AreEqual(2, tokens.Length);
+            Assert.AreEqual(3, tokens.Length);
             Assert.AreEqual(tokens[0].Kind, t1Kind);
             Assert.AreEqual(tokens[0].Text, t1Text);
-            Assert.AreEqual(tokens[1].Kind, t2Kind);
-            Assert.AreEqual(tokens[1].Text, t2Text);
+            Assert.AreEqual(tokens[2].Kind, t2Kind);
+            Assert.AreEqual(tokens[2].Text, t2Text);
         }
 
         [Theory]
@@ -59,16 +59,16 @@ namespace CASC_Test.Tests
                                                           SyntaxKind separatorKind, string separatorText,
                                                           SyntaxKind t2Kind, string t2Text)
         {
-            var text = t1Text + separatorText + t2Text;
+            var text = $"{t1Text} {separatorText} {t2Text}";
             var tokens = SyntaxTree.ParseTokens(text).ToArray();
 
-            Assert.AreEqual(3, tokens.Length);
+            Assert.AreEqual(4, tokens.Length);
             Assert.AreEqual(tokens[0].Kind, t1Kind);
             Assert.AreEqual(tokens[0].Text, t1Text);
-            Assert.AreEqual(tokens[1].Kind, separatorKind);
-            Assert.AreEqual(tokens[1].Text, separatorText);
-            Assert.AreEqual(tokens[2].Kind, t2Kind);
-            Assert.AreEqual(tokens[2].Text, t2Text);
+            Assert.AreEqual(tokens[2].Kind, separatorKind);
+            Assert.AreEqual(tokens[2].Text, separatorText);
+            Assert.AreEqual(tokens[4].Kind, t2Kind);
+            Assert.AreEqual(tokens[4].Text, t2Text);
         }
 
         public static IEnumerable<object[]> GetTokensData()

--- a/src/CASC/CodeParser/Syntax/Lexer.cs
+++ b/src/CASC/CodeParser/Syntax/Lexer.cs
@@ -1,27 +1,10 @@
 using CASC.CodeParser.Utilities;
-using System.Collections.Generic;
 using CASC.CodeParser.Text;
 
 namespace CASC.CodeParser.Syntax
 {
     internal sealed class Lexer
     {
-        private static readonly List<char> _exceptionChineseChar = new List<char> {
-            // Common Operators
-            '加', // Add                加
-            '減', // Minus              減
-            '乘', // Multiply           乘
-            '除', // Divide             除
-            '點', // Point              點
-            '正', // Idnetity           正
-            '負', // Negation           負
-            '且', // Logical AND        且
-            '或', // Logical OR         或
-            '反', // Logical Negation   反
-            '是', // Eqauls             是
-            '不', // Not Equals         不是
-            '賦'  // Assign             賦
-        };
 
         private readonly SourceText _text;
         private readonly DiagnosticPack _diagnostics = new DiagnosticPack();
@@ -41,7 +24,6 @@ namespace CASC.CodeParser.Syntax
 
         private char Current => Peek(0);
         private char LookAhead => Peek(1);
-        private char LookTwiceAhead => Peek(2);
 
         private char Peek(int offset)
         {
@@ -65,48 +47,46 @@ namespace CASC.CodeParser.Syntax
                     _kind = SyntaxKind.EndOfFileToken;
                     break;
 
-                case '加':
-                case '正':
                 case '+':
                     _kind = SyntaxKind.PlusToken;
                     _position++;
                     break;
-                case '減':
-                case '負':
+
                 case '-':
                     _kind = SyntaxKind.MinusToken;
                     _position++;
                     break;
-                case '乘':
+
                 case '*':
                     _kind = SyntaxKind.StarToken;
                     _position++;
                     break;
-                case '除':
+
                 case '/':
                     _kind = SyntaxKind.SlashToken;
                     _position++;
                     break;
+
                 case '(':
                     _kind = SyntaxKind.OpenParenthesesToken;
                     _position++;
                     break;
+
                 case ')':
                     _kind = SyntaxKind.CloseParenthesesToken;
                     _position++;
                     break;
+
                 case '{':
                     _kind = SyntaxKind.OpenBraceToken;
                     _position++;
                     break;
+
                 case '}':
                     _kind = SyntaxKind.CloseBraceToken;
                     _position++;
                     break;
-                case '且':
-                    _kind = SyntaxKind.AmpersandAmpersandToken;
-                    _position++;
-                    break;
+
                 case '&':
                     if (LookAhead == '&')
                     {
@@ -115,10 +95,7 @@ namespace CASC.CodeParser.Syntax
                         break;
                     }
                     break;
-                case '或':
-                    _kind = SyntaxKind.PipePipeToken;
-                    _position++;
-                    break;
+
                 case '|':
                     if (LookAhead == '|')
                     {
@@ -127,10 +104,7 @@ namespace CASC.CodeParser.Syntax
                         break;
                     }
                     break;
-                case '反':
-                    _kind = SyntaxKind.BangToken;
-                    _position++;
-                    break;
+
                 case '!':
                     if (LookAhead == '=')
                     {
@@ -141,54 +115,17 @@ namespace CASC.CodeParser.Syntax
                     _kind = SyntaxKind.BangToken;
                     _position++;
                     break;
-                case '不':
-                    if (LookAhead == '是')
-                    {
-                        _kind = SyntaxKind.BangEqualsToken;
-                        _position += 2;
-                        break;
-                    }
-                    break;
-                case '是':
-                    _kind = SyntaxKind.EqualsEqualsToken;
-                    _position++;
-                    break;
+
                 case '=':
                     if (LookAhead != '=')
-                        goto case '賦';
+                    {
+                        _kind = SyntaxKind.EqualsToken;
+                        _position++;
+                    }
                     _kind = SyntaxKind.EqualsEqualsToken;
                     _position += 2;
                     break;
-                case '賦':
-                    _kind = SyntaxKind.EqualsToken;
-                    _position++;
-                    break;
-                case '大':
-                    _position++;
-                    if (Current == '等' && LookAhead == '於')
-                    {
-                        _kind = SyntaxKind.GreaterEqualsToken;
-                        _position += 2;
-                    }
-                    else if (Current == '於')
-                    {
-                        _kind = SyntaxKind.GreaterToken;
-                        _position++;
-                    }
-                    break;
-                case '小':
-                    _position++;
-                    if (Current == '等' && LookAhead == '於')
-                    {
-                        _kind = SyntaxKind.LessEqualsToken;
-                        _position += 2;
-                    }
-                    else if (Current == '於')
-                    {
-                        _kind = SyntaxKind.LessToken;
-                        _position++;
-                    }
-                    break;
+
                 case '>':
                     _position++;
                     if (Current != '=')

--- a/src/CASC/CodeParser/Syntax/SyntaxFacts.cs
+++ b/src/CASC/CodeParser/Syntax/SyntaxFacts.cs
@@ -54,6 +54,51 @@ namespace CASC.CodeParser.Syntax
         {
             switch (text)
             {
+                case "正":
+                case "加":
+                    return SyntaxKind.PlusToken;
+
+                case "負":
+                case "減":
+                    return SyntaxKind.MinusToken;
+
+                case "乘":
+                    return SyntaxKind.StarToken;
+
+                case "除":
+                    return SyntaxKind.SlashToken;
+
+                case "且":
+                    return SyntaxKind.AmpersandAmpersandToken;
+
+                case "或":
+                    return SyntaxKind.PipePipeToken;
+
+                case "反":
+                    return SyntaxKind.BangToken;
+
+                case "是":
+                    return SyntaxKind.EqualsEqualsToken;
+
+                case "不是":
+                    return SyntaxKind.BangEqualsToken;
+
+                case "為":
+                case "賦":
+                    return SyntaxKind.EqualsToken;
+
+                case "大等於":
+                    return SyntaxKind.GreaterEqualsToken;
+                
+                case "大於":
+                    return SyntaxKind.GreaterToken;
+
+                case "小等於":
+                    return SyntaxKind.LessEqualsToken;
+
+                case "小於":
+                    return SyntaxKind.LessToken;
+
                 case "真":
                 case "true":
                     return SyntaxKind.TrueKeyword;


### PR DESCRIPTION
In current dev stage, the following casc source won't successfully compile  and  run:
```casc
val 加 = 1
(Crashed since plus does not recognize as a name)
```
The reason it would crash is that the word 加 is a operator word which will firstly check by lexer if it is a operator before it does not recognize such word and goes down to be parsed as a name syntax.

In this PR, we're trying to fix this issue by moving mandarin operators (正, 加, 負, 減 etc.) to our SyntaxFact.cs, which means these words will be lexed after the operators are being lexed. TL;DR the word will requires whitespaces to separate as same as what for, while keywords does. 